### PR TITLE
test pull request with local model instead of remote

### DIFF
--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           source activate
           echo "Sample model id selected: $MODEL_ID"
-          ersilia -v fetch $MODEL_ID 
+          ersilia -v fetch $MODEL_ID --repo_path .
           ersilia -v serve $MODEL_ID
           ersilia sample -n 5 -f input.csv
           ersilia -v api -i input.csv


### PR DESCRIPTION
closes https://github.com/ersilia-os/eos-template/issues/13

Finally, we need to be able to fetch a model before it is accepted in the PR for model incorporation, as pointed out by
[@megamanics](https://github.slack.com/team/U03DAKUT6AV)
. There is an option in the fetch command that could be useful for this: ersilia fetch MODEL_ID --repo_path /path/to/local/repo/folder