### PR TITLE
Set Python to 3.10.10 in github workflows

### DIFF
--- a/.github/workflows/test-model-pr.yml
+++ b/.github/workflows/test-model-pr.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
         
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+      
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+         
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/upload-model-to-dockerhub.yml
+++ b/.github/workflows/upload-model-to-dockerhub.yml
@@ -113,6 +113,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+
       - name: Install dependencies
         run: |
           source activate

--- a/.github/workflows/upload-model-to-s3.yml
+++ b/.github/workflows/upload-model-to-s3.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
+      - name: Set Python to 3.10.10
+        run:
+         conda install -y python=3.10.10 
+      
       - name: Install dependencies
         run: |
           source activate


### PR DESCRIPTION
@GemmaTuron and @miquelduranfrigola,

In the four workflows that require installing ersilia, a step has been added to set Python to 3.10.10 by running `conda install -y python=3.10.10 `