### PR TITLE
Add a timeout for multiplatform builds

### DIFF
--- a/.github/workflows/upload-model-to-dockerhub.yml
+++ b/.github/workflows/upload-model-to-dockerhub.yml
@@ -64,6 +64,7 @@ jobs:
         id: buildMultiple
         continue-on-error: true
         uses: docker/build-push-action@v5
+        timeout-minutes: 45
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
because for some models, ARM builds get stuck at ersilia fetch stage and the pipeline times out.