### PR TITLE
Add a test stage to our Docker Build and Push workflow

### DIFF
--- a/.github/workflows/upload-model-to-dockerhub.yml
+++ b/.github/workflows/upload-model-to-dockerhub.yml
@@ -59,6 +59,30 @@ jobs:
           wget https://raw.githubusercontent.com/ersilia-os/ersilia/master/.github/scripts/place_a_dockerfile_in_current_eos_repo.py
           python -m pip install requests
           python place_a_dockerfile_in_current_eos_repo.py $REPO_NAME
+
+      # We cannot tag it as anything other than latest because 
+      # ersilia cli only looks for the 'latest' tag
+      - name: Build and export to Docker
+        id: buildForTest
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          load: true
+          tags: ersiliaos/${{ github.event.repository.name }}:latest
+        
+      - name: Test
+        id: testBuiltImage
+        run: |
+          export PULL_IMAGE=n
+          ersilia -v serve ${{ github.event.repository.name }}
+          ersilia -v run -i "CCCC" -o "output.json"
+          expected=$(jq '.[0].output.outcome[]' output.json | wc -l)
+          result=$(jq '.[0].output.outcome[] | select(. != null)' output.json | wc -l)
+          if [ $expected -ne $ $result ]
+            then
+              echo "Error in model output, aborting build and push"
+              exit 1
+          fi
         
       - name: Build and push
         id: buildMultiple


### PR DESCRIPTION
Added two new steps to the workflow, namely, buildForTest, and testBuiltImage. 

The `buildForTest` step only builds an amd64 image with the latest tag since we test this image through the ersilia CLI which only looks for the latest tag. 

The `testBuiltImage` serves the newly built model image and tests it against a simple input. Then I use jq to count the fields within the model outcome followed by checking for null values in the output. If there are any null values within the output this test fails and the model push will not succeed. 

Upon success of this test, the subsequent build stage will only build the arm64 image and reuse the previously built amd64 image and push them both to DockerHub.