### PR TITLE
Uploading log files as artifacts if action fails

### DIFF
--- a/.github/workflows/test-model-pr.yml
+++ b/.github/workflows/test-model-pr.yml
@@ -78,8 +78,9 @@ jobs:
           ersilia close
           
       - name: Upload log output
+        if: always()
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1
         with:
           name: debug-logs
-          retention-days: 1
-          path: /home/runner/eos/console.log
+          retention-days: 14
+          path: /home/runner/eos/*.log

--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -109,9 +109,9 @@ jobs:
           ersilia close
           
       - name: Upload log output
+        if: always()
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1
         with:
           name: debug-logs
-          retention-days: 1
-          path: /home/runner/eos/console.log
-
+          retention-days: 14
+          path: /home/runner/eos/*.log


### PR DESCRIPTION
**Description**

If Action Fails, we want to upload the log files as artifacts so a contributor can have access to them and use them to debug.

**Changes to be made**

- Upload current and console logs
- Upload and keep them as artifacts for 14 days
- make sure they are uploaded if the action fails or runs successfully


**Status**

All changes made

**To do**

Identify other essential log files to be uploaded
