### PR TITLE
Add --track flag to the Test built image step in the Docker build pipeline for Ersilia models

### DIFF
--- a/.github/workflows/upload-bentoml.yml
+++ b/.github/workflows/upload-bentoml.yml
@@ -97,11 +97,14 @@ jobs:
         id: testBuiltImage
         env:
           PULL_IMAGE: n
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         run: |
           ersilia -v fetch ${{ github.event.repository.name }} --from_dockerhub
           ersilia -v serve ${{ github.event.repository.name }}
           ersilia example -n 1 -f input.csv --predefined
-          ersilia -v run -i "input.csv" -o "output.csv"
+          ersilia -v run -i "input.csv" -o "output.csv" --track
           ersilia close
           output=$(python .github/scripts/verify_model_outcome.py output.csv)
           if echo "$output" | grep -q "All outcomes are null"; then

--- a/.github/workflows/upload-bentoml.yml
+++ b/.github/workflows/upload-bentoml.yml
@@ -102,9 +102,9 @@ jobs:
           AWS_DEFAULT_REGION: us-east-1
         run: |
           ersilia -v fetch ${{ github.event.repository.name }} --from_dockerhub
-          ersilia -v serve ${{ github.event.repository.name }}
+          ersilia -v serve ${{ github.event.repository.name }} --track #Added --track here
           ersilia example -n 1 -f input.csv --predefined
-          ersilia -v run -i "input.csv" -o "output.csv" --track
+          ersilia -v run -i "input.csv" -o "output.csv"
           ersilia close
           output=$(python .github/scripts/verify_model_outcome.py output.csv)
           if echo "$output" | grep -q "All outcomes are null"; then

--- a/.github/workflows/upload-ersilia-pack.yml
+++ b/.github/workflows/upload-ersilia-pack.yml
@@ -81,9 +81,9 @@ jobs:
         continue-on-error: true  # Allow this to fail
         run: |
           ersilia -v fetch ${{ github.event.repository.name }} --from_dockerhub
-          ersilia -v serve ${{ github.event.repository.name }}
+          ersilia -v serve ${{ github.event.repository.name }} --track #Added --track here
           ersilia example -n 1 -f input.csv --predefined
-          ersilia -v run -i "input.csv" -o "output.csv" --track
+          ersilia -v run -i "input.csv" -o "output.csv" 
           ersilia close
           output=$(python .github/scripts/verify_model_outcome.py output.csv)
           if echo "$output" | grep -q "All outcomes are null"; then

--- a/.github/workflows/upload-ersilia-pack.yml
+++ b/.github/workflows/upload-ersilia-pack.yml
@@ -74,13 +74,16 @@ jobs:
         id: testBuiltImageErsiliaPack
         env:
           PULL_IMAGE: n
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
         if: steps.buildForTestErsiliaPack.outcome == 'success'
         continue-on-error: true  # Allow this to fail
         run: |
           ersilia -v fetch ${{ github.event.repository.name }} --from_dockerhub
           ersilia -v serve ${{ github.event.repository.name }}
           ersilia example -n 1 -f input.csv --predefined
-          ersilia -v run -i "input.csv" -o "output.csv"
+          ersilia -v run -i "input.csv" -o "output.csv" --track
           ersilia close
           output=$(python .github/scripts/verify_model_outcome.py output.csv)
           if echo "$output" | grep -q "All outcomes are null"; then


### PR DESCRIPTION
Description:

This pull request updates the Docker build pipeline for Ersilia models by running the models with the --track flag during the "Test built image" step.

Changes include:

    Ersilia Pack: Updated the Docker pipeline to run Ersilia models with the --track flag during the "Test built image" step.
    BentoML: Integrated the --track flag in the testing step when running Ersilia models using BentoML.

This change ensures better tracking and reporting of model runs during the Docker build process, allowing for more robust monitoring and debugging capabilities.
Why this change is necessary:

    The --track flag improves model run monitoring by enabling logging and tracking, which can help with performance evaluation and debugging.
    This ensures that both Ersilia Pack and BentoML models follow the same testing practices, maintaining consistency across different toolsets.

Testing:

    Tested the Docker pipeline for both Ersilia Pack and BentoML models to ensure that the --track flag functions as expected during the "Test built image" step.
    Verified that logs and tracking data are properly generated and accessible after the test runs.

Related:

This pull request is related to issue [#925](https://github.com/ersilia-os/ersilia/issues/925) in a ersilia repository, where a similar implementation for automatic testing of the --track flag was introduced. Although the issue pertains to a different repo, the changes here are aligned with that effort to streamline testing and tracking across platforms.
