### PR TITLE
Add GitHub Actions step to upload output.csv as an artifact

### DIFF
--- a/.github/workflows/test-model-pr.yml
+++ b/.github/workflows/test-model-pr.yml
@@ -1,6 +1,6 @@
 name: Model Test on PR
 
-on: 
+on:
   pull_request:
 
 jobs:
@@ -12,14 +12,14 @@ jobs:
         with:
           lfs: true
 
-# This might stop working in the future, so we need to keep an eye on it
+      # This might stop working in the future, so we need to keep an eye on it
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: true
-          
+
           # all of these default to true, but feel free to set to
           # "false" if necessary for your workflow
           android: true
@@ -30,14 +30,13 @@ jobs:
 
       - name: Add conda to system path
         run: echo $CONDA/bin >> $GITHUB_PATH
-      
+
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
-        
+
       - name: Set Python to 3.10.10
-        run:
-         conda install -y python=3.10.10 
-      
+        run: conda install -y python=3.10.10
+
       - name: Install dependencies
         run: |
           source activate
@@ -53,7 +52,7 @@ jobs:
           echo "After conda init"
           conda init
           python -m pip install git+https://github.com/ersilia-os/ersilia.git
-  
+
       - name: Predict output
         env:
           MODEL_ID: ${{ github.event.repository.name }}
@@ -67,9 +66,11 @@ jobs:
             ersilia -v fetch $MODEL_ID --from_dir .
             ersilia -v serve $MODEL_ID
             ersilia example -n 5 -f input.csv --predefined
-            ersilia -v api -i input.csv
+            ersilia -v run -i input.csv
             ersilia close
-          
+            echo "Perform detail check on model: $MODEL_ID"
+            ersilia -v test $MODEL_ID -d . --inspect -l deep
+
       - name: Upload log output
         if: always()
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1

--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -1,8 +1,8 @@
 name: Model test on push
 
 on:
-  push: 
-    branches: ['main']
+  push:
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:
@@ -15,16 +15,16 @@ jobs:
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-          lfs: 'true'
-          
-# This might stop working in the future, so we need to keep an eye on it
+          lfs: "true"
+
+      # This might stop working in the future, so we need to keep an eye on it
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: true
-          
+
           # all of these default to true, but feel free to set to
           # "false" if necessary for your workflow
           android: true
@@ -35,14 +35,13 @@ jobs:
 
       - name: Add conda to system path
         run: echo $CONDA/bin >> $GITHUB_PATH
-      
+
       - name: Source conda
         run: source $CONDA/etc/profile.d/conda.sh
 
       - name: Set Python to 3.10.10
-        run:
-         conda install -y python=3.10.10 
-         
+        run: conda install -y python=3.10.10
+
       - name: Install dependencies
         run: |
           source activate
@@ -58,7 +57,7 @@ jobs:
           echo "After conda init"
           conda init
           python -m pip install git+https://github.com/ersilia-os/ersilia.git
-  
+
       - name: Update metadata to AirTable
         id: update-metadata-to-airtable
         env:
@@ -113,38 +112,55 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           amend: true
           force: true
-      
+
       - name: Fetch model
         env:
           MODEL_ID: ${{ github.event.repository.name }}
         run: |
-            source activate
-            ersilia -v fetch $MODEL_ID --from_dir .
-            FOLDER="$HOME/eos/repository/$MODEL_ID"
-            if [ ! -d "$FOLDER" ]; then
-              echo "Error: Folder '$FOLDER' does not exist." >&2
-              exit 1
-            fi
+          source activate
+          ersilia -v fetch $MODEL_ID --from_dir .
+          FOLDER="$HOME/eos/repository/$MODEL_ID"
+          if [ ! -d "$FOLDER" ]; then
+            echo "Error: Folder '$FOLDER' does not exist." >&2
+            exit 1
+          fi
 
       - name: Generate input and run model
         env:
           MODEL_ID: ${{ github.event.repository.name }}
         run: |
-            source activate
-            ersilia -v serve $MODEL_ID
-            ersilia example -n 5 -f input.csv --predefined
-            ersilia -v run -i "input.csv" -o "output.csv"
-            ersilia close
-            cat output.csv
-      
+          source activate
+          ersilia -v serve $MODEL_ID
+          ersilia example -n 5 -f input.csv --predefined
+          ersilia -v run -i "input.csv" -o "output.csv"
+          ersilia close
+          cat output.csv
+
       - name: Test output
         run: |
-            output=$(python .github/scripts/verify_model_outcome.py output.csv)
-            if echo "$output" | grep -q "All outcomes are null"; then
-              echo "Error in model outcome, aborting test"
-              exit 1
-            fi
-            rm output.csv
+          output=$(python .github/scripts/verify_model_outcome.py output.csv)
+          if echo "$output" | grep -q "All outcomes are null"; then
+            echo "Error in model outcome, aborting test"
+            exit 1
+          fi
+      
+      name: Upload output.csv
+        if: always()
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1
+        with:
+          name: model-output
+          retention-days: 14
+          path: output.csv
+
+      - run: rm output.csv
+
+      - name: Perform detail check on model
+        env:
+          MODEL_ID: ${{ github.event.repository.name }}
+        run: |
+          source activate
+          ersilia delete $MODEL_ID
+          ersilia -v test $MODEL_ID -d $MODEL_ID --inspect --remote -l deep
 
       - name: Upload log output
         if: always()

--- a/.github/workflows/test-model.yml
+++ b/.github/workflows/test-model.yml
@@ -144,7 +144,7 @@ jobs:
             exit 1
           fi
       
-      name: Upload output.csv
+      - name: Upload output.csv
         if: always()
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1
         with:

--- a/.github/workflows/upload-bentoml.yml
+++ b/.github/workflows/upload-bentoml.yml
@@ -122,7 +122,7 @@ jobs:
 
       - run: rm output.csv
 
-      # If test failed, we tag the image as dev
+      # If test failed,  we tag the image as dev
       - name: Tag Dev image
         id: tagDevImage
         if: steps.testBuiltImage.outcome == 'failure'

--- a/.github/workflows/upload-bentoml.yml
+++ b/.github/workflows/upload-bentoml.yml
@@ -111,7 +111,16 @@ jobs:
             echo "Error in model outcome, aborting build"
             exit 1
           fi
-          rm output.csv
+      
+      - name: Upload output.csv
+        if: always()
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1
+        with:
+          name: model-output
+          retention-days: 14
+          path: output.csv
+
+      - run: rm output.csv
 
       # If test failed, we tag the image as dev
       - name: Tag Dev image

--- a/.github/workflows/upload-ersilia-pack.yml
+++ b/.github/workflows/upload-ersilia-pack.yml
@@ -102,7 +102,7 @@ jobs:
 
       - run: rm output.csv
 
-      # If test failed, we tag the image as dev
+      # If test failed, we  tag the image as dev
       - name: Tag Dev image
         id: tagDevImage
         if: steps.testBuiltImageErsiliaPack.outcome == 'failure'

--- a/.github/workflows/upload-ersilia-pack.yml
+++ b/.github/workflows/upload-ersilia-pack.yml
@@ -91,7 +91,16 @@ jobs:
             echo "Error in model outcome, aborting build"
             exit 1
           fi
-          rm output.csv
+      
+      - name: Upload output.csv
+        if: always()
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1
+        with:
+          name: model-output
+          retention-days: 14
+          path: output.csv
+
+      - run: rm output.csv
 
       # If test failed, we tag the image as dev
       - name: Tag Dev image


### PR DESCRIPTION
- [x]  Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

**Description**
This pull request adds a new step to the GitHub Actions workflow (`test-model.yml`, `upload-ersilia-pack.yml,` and `upload-bentoml.yml`) to upload the `output.csv` file as an artifact. This enhancement allows the `output.csv` generated during the workflow to be easily downloaded and reviewed after the workflow execution. This is so that we can also inspect the output, as an additional check, to see if the model really worked. Ideally, the test for null outcomes should catch this, but we've been seeing instances of when this check passes, but the model still generates nothing, even for non generative models that should work with most inputs.

**Changes Made**

- Added an artifact upload step to all three workflows: `test-model.yml`, `upload-ersilia-pack.yml,` and `upload-bentoml.yml`
- Ensures `output.csv` is saved as an artifact for inspection and debugging.
- Upload the `output.csv` file as an artifact named model-output with a retention period of 14 days.
- Delete the `output.csv` file after it has been successfully uploaded to GitHub as an artifact.


Fixes #73