### PR TITLE
Add step to delete mock.txt in test-model-pr.yml workflow

### DIFF
--- a/.github/workflows/test-model-pr.yml
+++ b/.github/workflows/test-model-pr.yml
@@ -71,6 +71,16 @@ jobs:
             echo "Perform detail check on model: $MODEL_ID"
             ersilia -v test $MODEL_ID -d . --inspect -l deep
 
+      
+      - name: Remove mock.txt if it exists
+        run: |
+          if [ -f "mock.txt" ]; then
+            echo "Removing mock.txt file"
+            rm "mock.txt"
+          else
+            echo "mock.txt not found, skipping removal"
+          fi
+
       - name: Upload log output
         if: always()
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb #pin v3.1.1


### PR DESCRIPTION
- [x]  Have you followed the guidelines in our [Contribution Guide](https://github.com/ersilia-os/ersilia/blob/master/CONTRIBUTING.md)
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

**Description**
This task involves modifying the workflow to automatically remove a mock.txt file created during the process of creating a model repository. The mock.txt file is initially added as a placeholder to enable Git LFS (Large File Storage) functionality. The goal is to add a step in the `.github/workflows/test-model-pr.yml` workflow to check for the existence of mock.txt and delete it if found.

The new step has been added after the predict-output stage.

**Changes Made**
I modified the workflow by adding a step after the` predict-output `stage to check if `mock.txt `exists in the root of the repository and removes it if found.

- Checks if `mock.txt `exists.
- Deletes `mock.txt` if it exists.

Closes #69 